### PR TITLE
Feature: Ctrl-Arrow right and Ctrl-Arrow left 

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -804,11 +804,19 @@ class ConfigGlobal:
 
             Command("MoveLeft", "Move left.", [wx.WXK_LEFT], isMovement = True),
 
+            Command("MoveNextWord", "Move to start of next word.",
+                    [util.Key(wx.WXK_RIGHT, ctrl = True).toInt()],
+                    isMovement = True, isFixed = True),
+
             Command("MovePageDown", "Move one page down.",
                     [wx.WXK_PAGEDOWN], isMovement = True),
 
             Command("MovePageUp", "Move one page up.",
                     [wx.WXK_PAGEUP], isMovement = True),
+
+            Command("MovePrevWord", "Move to start of previous word.",
+                    [util.Key(wx.WXK_LEFT, ctrl = True).toInt()],
+                    isMovement = True, isFixed = True),
 
             Command("MoveRight", "Move right.", [wx.WXK_RIGHT],
                     isMovement = True),

--- a/src/screenplay.py
+++ b/src/screenplay.py
@@ -2738,32 +2738,34 @@ Generated with <a href="http://www.trelby.org">Trelby</a>.</p>
 
     def moveNextWordCmd(self, cs):
         if not self.acItems:
-            spaceFound = False
             l = self.line
             i = self.column
-
             t = self.lines[l].text
+            firstReadFlag = False
             while True:
-                if i == len(self.lines[l].text): # end of line
-                    l = l+1
-                    i = 0
-                    if l == len(self.lines): #last line
-                        return
-                    else:
-                        self.column = i
-                        self.line = l
-                        return
+                if t == '': # empty line
+                    self.line += 1
+                    return
 
-                if spaceFound:
-                    if not t[i].isspace():
-                        self.column = i
-                        self.line = l
-                        return
+                if i+1 == len(self.lines[l].text): # end of line
+                    if firstReadFlag==False: # event started at the end of the line
+                        if l+1 == len(self.lines):
+                            return
+                        l += 1
+                        i = 0
+                        t = self.lines[l].text
+                        
+                    self.column = i 
+                    self.line = l
+                    return 
+
+                if t[i+1].isspace() and firstReadFlag: # shifting the cursor to the end of the word
+                    self.column = i
+                    return 
                 else:
-                    if t[i].isspace():
-                        spaceFound = True
-
-                i = i+1
+                    i+=1
+                if firstReadFlag == False:
+                    firstReadFlag = True
 
     def movePrevWordCmd(self, cs):
         #returns a reverse list of indexes of words in string s.
@@ -2772,8 +2774,11 @@ Generated with <a href="http://www.trelby.org">Trelby</a>.</p>
             if s and not s[0].isspace():
                 l.append(0)
             for i in xrange(1, len(s)):
+                if s[i-1].isspace() and i == len(s):
+                    l.append(i)
                 if not s[i].isspace() and s[i-1].isspace():
                     l.append(i)
+
             l.reverse()
             return l
 

--- a/src/screenplay.py
+++ b/src/screenplay.py
@@ -2736,6 +2736,67 @@ Generated with <a href="http://www.trelby.org">Trelby</a>.</p>
 
             cs.doAutoComp = cs.AC_KEEP
 
+    def moveNextWordCmd(self, cs):
+        if not self.acItems:
+            spaceFound = False
+            l = self.line
+            i = self.column
+
+            t = self.lines[l].text
+            while True:
+                if i == len(self.lines[l].text): # end of line
+                    l = l+1
+                    i = 0
+                    if l == len(self.lines): #last line
+                        return
+                    else:
+                        self.column = i
+                        self.line = l
+                        return
+
+                if spaceFound:
+                    if not t[i].isspace():
+                        self.column = i
+                        self.line = l
+                        return
+                else:
+                    if t[i].isspace():
+                        spaceFound = True
+
+                i = i+1
+
+    def movePrevWordCmd(self, cs):
+        #returns a reverse list of indexes of words in string s.
+        def getWordIndex(s):
+            l = []
+            if s and not s[0].isspace():
+                l.append(0)
+            for i in xrange(1, len(s)):
+                if not s[i].isspace() and s[i-1].isspace():
+                    l.append(i)
+            l.reverse()
+            return l
+
+        if not self.acItems:
+            l = self.line
+            i = self.column
+
+            words = getWordIndex(self.lines[l].text)
+            while True:
+                for word in words:
+                    if word < i:
+                        self.column = word
+                        self.line = l
+                        return
+                l = l-1
+                if l == -1:
+                    self.line = 0
+                    self.column = 0
+                    return
+                words = getWordIndex(self.lines[l].text)
+                if words:
+                    i = words[0] + 1
+
     def moveLineEndCmd(self, cs):
         if self.acItems:
             self.lines[self.line].text = self.acItems[self.acSel]

--- a/src/trelby.py
+++ b/src/trelby.py
@@ -1225,11 +1225,17 @@ class MyCtrl(wx.Control):
     def cmdMoveLeft(self, cs):
         self.sp.moveLeftCmd(cs)
 
+    def cmdMoveNextWord(self, cs):
+        self.sp.moveNextWordCmd(cs)
+
     def cmdMovePageDown(self, cs):
         self.pageCmd(cs, 1)
 
     def cmdMovePageUp(self, cs):
         self.pageCmd(cs, -1)
+
+    def cmdMovePrevWord(self, cs):
+        self.sp.movePrevWordCmd(cs)
 
     def cmdMoveRight(self, cs):
         self.sp.moveRightCmd(cs)

--- a/tests/movement.py
+++ b/tests/movement.py
@@ -11,7 +11,7 @@ def testMoveRight():
     assert (sp.line == 1) and (sp.column == 0)
     sp.cmd("moveEnd")
     sp.cmd("moveRight")
-    assert (sp.line == 158) and (sp.column == 5)
+    assert (sp.line == 161) and (sp.column == 4)
 
 def testMoveLeft():
     sp = u.load()
@@ -43,7 +43,7 @@ def testMoveDown():
     assert (sp.line == 4) and (sp.column == 31)
     sp.cmd("moveEnd")
     sp.cmd("moveDown")
-    assert sp.line == 158
+    assert sp.line == 161
 
 def testMoveLineEnd():
     sp = u.load()
@@ -59,7 +59,7 @@ def testMoveLineStart():
 def testMoveEnd():
     sp = u.load()
     sp.cmd("moveEnd")
-    assert (sp.line == 158) and (sp.column == 5)
+    assert (sp.line == 161) and (sp.column == 4)
 
 def testMoveStart():
     sp = u.load()
@@ -91,4 +91,34 @@ def testMoveSceneDown():
     assert (sp.line == 30) and (sp.column == 0)
     sp.cmd("moveEnd")
     sp.cmd("moveSceneDown")
-    assert (sp.line == 158) and (sp.column == 0)
+    assert (sp.line == 161) and (sp.column == 0)
+
+def testMoveNextWord():
+    sp = u.load()
+    sp.line = 157
+    sp.column = 0
+    sp.cmd("moveNextWord")
+    assert(sp.line==157) and (sp.column==4)
+    sp.cmd("moveNextWord")
+    assert(sp.line==158) and (sp.column==0)
+    sp.cmd("moveNextWord")
+    assert(sp.line==158) and (sp.column==4)
+    sp.cmd("moveNextWord")
+    assert(sp.line==159) and (sp.column==0)
+    sp.cmd("moveNextWord")
+    assert(sp.line==160) and (sp.column==0)
+    sp.cmd("moveNextWord")
+    assert(sp.line==161) and (sp.column==0)
+    sp.cmd("moveNextWord")
+    assert(sp.line==161) and (sp.column==3)
+
+def testMovePrevWord():
+    sp = u.load()
+    sp.line = 161
+    sp.column = 3
+    sp.cmd("movePrevWord")
+    assert(sp.line==161) and (sp.column==0)
+    sp.cmd("movePrevWord")
+    assert(sp.line==158) and (sp.column==0)
+    sp.cmd("movePrevWord")
+    assert(sp.line==157) and (sp.column==0)

--- a/tests/test.trelby
+++ b/tests/test.trelby
@@ -298,3 +298,6 @@ Element/Note/Export/Underlined:False
 .:Intriguing.
 ._JASON
 .:Very.
+..
+..
+.:Very


### PR DESCRIPTION
Added a feature on Ctrl+(arrow key right) and Ctrl+(arrow key left).
This will let the user move word by word forward and backward. This is expected to behave just like any other editor. I have also added tests for the same. 

I did this for yesterday's dev-sprint in Bangalore led by @anilgulecha  