### PR TITLE
Updated README.md instructions for Debian builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@ Trelby is a screenplay writing program. See http://www.trelby.org/ for
 more details.
 
 ### About this project
-This is a fork of the original codebase from https://github.com/trelby/trelby, which as of this writing appears to be dormant.
+This is a fork of the original codebase from https://github.com/trelby/trelby, >
 
-The major difference of this fork is conversion to Python 3.  I also have a list of possible enhancements in mind, and I'd love help updating the Windows packaging so that I can provide a Windows build.
+The major difference of this fork is conversion to Python 3.  I also have a lis>
 
 ### Installation
 
@@ -16,10 +16,12 @@ The major difference of this fork is conversion to Python 3.  I also have a list
 
 2. cd trelby
 
-3. pip3 install -r requirements.txt  
-   *Depending on your python version, you might run into https://github.com/wxWidgets/Phoenix/issues/2296. We recommend executing `pip3 install attrdict3` before installing the requirements in that case. If that still doesn't work, we recommend upgrading your python version.*
+3. sudo apt install python3-pip
 
-4. ./bin/trelby
+4. sudo ./requirements.txt
+   *Depending on your python version, you might run into https://github.com/wxW>
+
+5. ./bin/trelby
 
 #### Debian and variants
 

--- a/README.md
+++ b/README.md
@@ -18,10 +18,10 @@ The major difference of this fork is conversion to Python 3.  I also have a list
 
 3. sudo apt install python3-pip
 
-4. sudo ./requirements.txt
+4. sudo ./requirements.txt <br  />
    *Depending on your python version, you might run into https://github.com/wxWidgets/Phoenix/issues/2296. We recommend executing `pip3 install attrdict3` before installing the requirements in that case. If that still doesn't work, we recommend upgrading your python version.*
 
-5. ./bin/trelby
+6. ./bin/trelby
 
 #### Debian and variants
 
@@ -33,8 +33,8 @@ https://software.opensuse.org//download.html?project=home%3Agwync&package=trelby
 
 1. make deb
 
-2. Install the resulting .deb file.
-   *If Trelby doesn't launch/work try to install these packages: sudo apt install python3-setuptools wxpython-tools python3-lxml python3-reportlab*
+2. Install the resulting .deb file <br  />
+    *If Trelby doesn't launch/work try to install these packages "sudo apt install python3-setuptools wxpython-tools python3-lxml python3-reportlab"*
 
 #### Fedora
 

--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@ Trelby is a screenplay writing program. See http://www.trelby.org/ for
 more details.
 
 ### About this project
-This is a fork of the original codebase from https://github.com/trelby/trelby, >
+This is a fork of the original codebase from https://github.com/trelby/trelby, which as of this writing appears to be dormant.
 
-The major difference of this fork is conversion to Python 3.  I also have a lis>
+The major difference of this fork is conversion to Python 3.  I also have a list of possible enhancements in mind, and I'd love help updating the Windows packaging so that I can provide a Windows build.
 
 ### Installation
 
@@ -19,7 +19,7 @@ The major difference of this fork is conversion to Python 3.  I also have a lis>
 3. sudo apt install python3-pip
 
 4. sudo ./requirements.txt
-   *Depending on your python version, you might run into https://github.com/wxW>
+   *Depending on your python version, you might run into https://github.com/wxWidgets/Phoenix/issues/2296. We recommend executing `pip3 install attrdict3` before installing the requirements in that case. If that still doesn't work, we recommend upgrading your python version.*
 
 5. ./bin/trelby
 
@@ -34,6 +34,7 @@ https://software.opensuse.org//download.html?project=home%3Agwync&package=trelby
 1. make deb
 
 2. Install the resulting .deb file.
+   *If Trelby doesn't launch/work try to install these packages: sudo apt install python3-setuptools wxpython-tools python3-lxml python3-reportlab*
 
 #### Fedora
 

--- a/README.md
+++ b/README.md
@@ -16,25 +16,26 @@ The major difference of this fork is conversion to Python 3.  I also have a list
 
 2. cd trelby
 
-3. sudo apt install python3-pip
-
-4. sudo ./requirements.txt <br  />
+3. pip3 install -r requirements.txt  
    *Depending on your python version, you might run into https://github.com/wxWidgets/Phoenix/issues/2296. We recommend executing `pip3 install attrdict3` before installing the requirements in that case. If that still doesn't work, we recommend upgrading your python version.*
 
-6. ./bin/trelby
+4. ./bin/trelby
 
 #### Debian and variants
 
-Download and install the .deb file for Ubuntu, Debian, or Raspian here:
+1. sudo apt install python3-setuptools wxpython-tools python3-lxml python3-reportlab
+
+2. Download and install the .deb file for Ubuntu, Debian, or Raspian here:
 
 https://software.opensuse.org//download.html?project=home%3Agwync&package=trelby
 
 - or -
 
-1. make deb
+1. sudo apt install python3-setuptools wxpython-tools python3-lxml python3-reportlab
 
-2. Install the resulting .deb file <br  />
-    *If Trelby doesn't launch/work try to install these packages "sudo apt install python3-setuptools wxpython-tools python3-lxml python3-reportlab"*
+2. make deb
+
+3. Install the resulting .deb file
 
 #### Fedora
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-apt install python3-setuptools
-apt install wxpython-tools
-apt install python3-lxml
-apt install python3-reportlab
-apt install python3-pytest>=7.0
+setuptools
+wxPython
+lxml
+reportlab
+pytest>=7.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-setuptools
-wxPython
-lxml
-reportlab
-pytest>=7.0
+apt install python3-setuptools
+apt install wxpython-tools
+apt install python3-lxml
+apt install python3-reportlab
+apt install python3-pytest>=7.0


### PR DESCRIPTION
While trying to install the .deb the program would just open and close instantly. After some trail and error I figured out that it was a dependency issue. 

I have updated the requirements.txt so it will download the correct packages (for Debian 12 at least) and updated the README.md instructions on how to install through said file. I have also added a note in case of .deb failure to try to download the dependencies manually.