### PR TITLE
Fixed bug breaking script settings

### DIFF
--- a/src/cfgdlg.py
+++ b/src/cfgdlg.py
@@ -1455,7 +1455,7 @@ class PDFFontsPanel(wx.Panel):
         for pfi in self.cfg.getPDFFontIds():
             pf = self.cfg.getPDFFont(pfi)
 
-            if pf.name and not pf.filename:
+            if pf.name and pf.filename != "":
                 userHasSetFontNameWithoutFile = True
 
             if pf.filename:


### PR DESCRIPTION
Before this patch, it would by default think that you tried setting a custom font name/path, even if you had nothing at all typed. This fixes it with a tiny change to where it tells trelby that only say True IF and ONLY if both are not empty. @limburgher I would greatly suggest making a version bump because this renders a settings dialogue completely broken, it will greatly confuse new users who don't know why it isn't working.

This also should close https://github.com/trelby/trelby/issues/34 which I opened earlier today before I dug deeper into the code as to why this wasn't working right.