### PR TITLE
Fixed deb build because making the deb package was broken.

### DIFF
--- a/debian/install
+++ b/debian/install
@@ -1,3 +1,3 @@
-resources/icon256.png /usr/share/resources
-trelby.desktop /usr/share/applications
+trelby/resources/icon256.png /usr/share/resources
+trelby/resources/trelby.desktop /usr/share/applications
 doc/trelby.1.gz /usr/share/man/man1

--- a/debian/rules
+++ b/debian/rules
@@ -1,7 +1,10 @@
+#!/usr/bin/make -f
+
 export PYBUILD_NAME=trelby
 export PYBUILD_INSTALL_ARGS="--install-lib=/usr/share/trelby/ --install-scripts=/usr/bin"
 %:
 	dh $@ --with python3 --buildsystem=pybuild
 
 override_dh_auto_install:
+	make -C doc manpage html
 	dh_auto_install --buildsystem=pybuild


### PR DESCRIPTION
I tried to build the deb package on my debian 12. It failed with both `dpkg-buildpackage -us -uc` and `debuild -us -uc`, the culprit was file paths were wrong.

In install file, I changed the location it was looking for those 3 files. In the rules file, for some reason, it wasn't generating the manuals rule, so I decided to just run the make manually before doing the rest. it runs fine, so I assume no issues have arise.