### PR TITLE
Very minor change to the file format to make way for future production mode

### DIFF
--- a/trelby/screenplay.py
+++ b/trelby/screenplay.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 import wx
+import re
 
 # linebreak types
 
@@ -209,7 +210,7 @@ class Screenplay:
         output += "#Start-Script \n"
 
         for i in range(len(self.lines)):
-            output += str(self.lines[i]) + "\n"
+            output += str(self.lines[i]) + "    &0&\n"
 
         return output.encode("UTF-8")
 
@@ -284,6 +285,8 @@ class Screenplay:
 
         for i in range(index, len(lines)):
             s = lines[i]
+            
+            
 
             if len(s) < 2:
                 raise error.MiscError("Line %d is too short." % (i + 1))
@@ -328,7 +331,8 @@ class Screenplay:
 
                 lb = config.char2lb(s[0], False)
                 lt = config.char2lt(s[1], False)
-                text = util.toInputStr(util.fromUTF8(s[2:]))
+                text = util.toInputStr(util.fromUTF8(s[2:])).removesuffix("&0&")
+                
 
                 # convert unknown lb types into LB_SPACE
                 if lb == None:
@@ -346,7 +350,13 @@ class Screenplay:
                     )
 
                 line = Line(lb, lt, text)
+
+                
+                
+            
                 sp.lines.append(line)
+                
+                
 
                 if lb != LB_LAST:
                     prevType = lt
@@ -371,6 +381,8 @@ class Screenplay:
         sp.paginate()
         sp.titles.sort()
         sp.locations.refresh(sp.getSceneNames())
+
+        
 
         msgs = []
 


### PR DESCRIPTION
I know some hold the opinion that it's too complex to add revisions and production mode. But I disagree because if it follows the KISS principles, of following simplicity, anything is possible.

This is an extremely tiny non breaking idea I'm adding that will be changed as time goes on where each element revisions is kept a few spaces at the end and a number like 0 or 5 and surrounded by two ampersand symbols. And then when importing, just strip it out. It needs tweaking, but I couldn't find any breakage so far. So it be an unnoticeable change.

And I tested it with files that didn't have the ampersand, it didn't complain or throw an error. Python just shrugged and kept going with what it was doing. Just tell me what you think, this doesn't break anything like I said, so production features can be possible someday.