### PR TITLE
create pipeline to build dmg file

### DIFF
--- a/.github/workflows/macos-dmg.yml
+++ b/.github/workflows/macos-dmg.yml
@@ -1,0 +1,61 @@
+name: Build macOS DMG
+
+on:
+  push:
+    branches: [ master ]
+  workflow_dispatch:
+
+jobs:
+  build-dmg:
+    runs-on: macos-latest
+    
+    steps:
+    - uses: actions/checkout@v4
+    
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.11'
+    
+    - name: Install system dependencies
+      run: brew install docbook-xsl
+    
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r requirements.txt
+    
+    - name: Get version
+      id: version
+      run: echo "version=$(python -c "import configparser; c=configparser.ConfigParser(); c.read('setup.cfg'); print(c['metadata']['version'])")" >> $GITHUB_OUTPUT
+
+    - name: Build DMG
+      run: make dmg VERSION=${{ steps.version.outputs.version }}
+    
+    - name: Create Release
+      id: create_release
+      uses: actions/create-release@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        tag_name: v${{ steps.version.outputs.version }}-${{ github.run_number }}
+        release_name: Trelby v${{ steps.version.outputs.version }} Build ${{ github.run_number }}
+        body: |
+          Automated macOS DMG build from commit ${{ github.sha }}
+          
+          **Changes:**
+          - Built from latest master branch
+          - macOS application bundle with proper metadata
+          - Includes all required dependencies
+        draft: true
+        prerelease: false
+    
+    - name: Upload DMG
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ steps.create_release.outputs.upload_url }}
+        asset_path: ./dist/Trelby-${{ steps.version.outputs.version }}.dmg
+        asset_name: Trelby-${{ steps.version.outputs.version }}-macos.dmg
+        asset_content_type: application/octet-stream

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,15 @@ MANIFEST
 # virtual environment and IDE stuff
 /venv/
 /.vscode/
+build/*
+dist/*
+.DS_Store
 
 #Choco
 *.nupkg
+
+# Generated build files (created by make dist)
+trelby/*.gz
+trelby/manual.html
+doc/manual.html
+doc/*.gz

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,10 @@
-.PHONY : clean dist
+.PHONY : clean dist dmg
 
 dist: trelby/names.txt.gz trelby/dict_en.dat.gz trelby/manual.html trelby/trelby.1.gz
 	cp trelby/trelby.1.gz doc/
+
+dmg:
+	./build_dmg.sh $(VERSION)
 
 trelby/names.txt.gz: trelby/names.txt
 	gzip -c trelby/names.txt > trelby/names.txt.gz

--- a/README.md
+++ b/README.md
@@ -43,3 +43,13 @@ Once chocolatey is set up (https://chocolatey.org/install):
 4. make
 
 5. ./trelby.py
+
+#### Building macOS DMG
+
+To create a macOS application bundle and DMG:
+
+1. Install py2app: `pip3 install py2app`
+2. Build DMG: `make dmg`
+3. The DMG file will be created in the `dist/` directory
+
+**Note:** Automated DMG builds are available from the [Releases](https://github.com/trelby/trelby/releases) page, built automatically on every commit to master.

--- a/build_dmg.sh
+++ b/build_dmg.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+APP_NAME="Trelby"
+VERSION="${1:-2.4.16.2}"
+DIST_DIR="dist"
+DMG_NAME="${APP_NAME}-${VERSION}.dmg"
+
+echo "Building ${APP_NAME} macOS DMG..."
+
+# Ensure clean build
+echo " Cleaning old builds..."
+rm -rf build "${DIST_DIR}"
+
+# Build app bundle
+make dist
+echo "Building .app with py2app..."
+python3 setup.py py2app
+
+APP_PATH="${DIST_DIR}/${APP_NAME}.app"
+
+if [ ! -d "${APP_PATH}" ]; then
+  echo " ERROR: ${APP_NAME}.app not found!"
+  exit 1
+fi
+
+# Prepare DMG staging
+echo "Preparing DMG staging..."
+STAGING="${DIST_DIR}/dmg"
+mkdir -p "${STAGING}"
+
+ditto "${APP_PATH}" "${STAGING}/${APP_NAME}.app"
+ln -sf /Applications "${STAGING}/Applications"
+
+# Build DMG
+echo "Creating DMG..."
+hdiutil create \
+  -volname "${APP_NAME}" \
+  -srcfolder "${STAGING}" \
+  -ov \
+  -format UDZO \
+  -imagekey zlib-level=9 \
+  "${DIST_DIR}/${DMG_NAME}"
+
+# Cleanup
+rm -rf "${STAGING}"
+
+# Verify
+echo "Verifying DMG..."
+hdiutil verify "${DIST_DIR}/${DMG_NAME}"
+
+echo "DMG created successfully:"
+echo "➡️  ${DIST_DIR}/${DMG_NAME}"
+
+echo ""
+echo "Install instructions:"
+echo "1. Open the DMG"
+echo "2. Drag ${APP_NAME}.app to Applications"
+echo "3. Eject the DMG"
+echo "4. Launch ${APP_NAME} from Applications"

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -11,7 +11,10 @@ MANPAGE_SOURCE = refentry.xml
 MANPAGE = trelby.1
 MANPAGE_GZIP_TARGET = $(MANPAGE).gz
 
-ifneq ($(wildcard /usr/share/sgml/docbook/stylesheet/xsl/),)
+ifneq ($(wildcard /opt/homebrew/opt/docbook-xsl/),)
+  XSL_MANPAGE = /opt/homebrew/opt/docbook-xsl/docbook-xsl/manpages/docbook.xsl
+  XSL_HTML = html-stylesheet-macos.xsl
+else ifneq ($(wildcard /usr/share/sgml/docbook/stylesheet/xsl/),)
   XSL_MANPAGE = /usr/share/sgml/docbook/stylesheet/xsl/docbook-xsl/manpages/docbook.xsl
   XSL_HTML = html-stylesheet-deb.xsl
 else

--- a/doc/html-stylesheet-macos.xsl
+++ b/doc/html-stylesheet-macos.xsl
@@ -1,0 +1,11 @@
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version='1.0'>
+
+  <xsl:import href="/opt/homebrew/opt/docbook-xsl/docbook-xsl/xhtml/docbook.xsl"/>
+
+  <xsl:param name="toc.section.depth">3</xsl:param>
+  <xsl:param name="annotate.toc">0</xsl:param>
+
+  <xsl:param name="section.autolabel" select="1"></xsl:param>
+  <xsl:param name="section.label.includes.component.label" select="1"></xsl:param>
+  
+</xsl:stylesheet>

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ wxPython>=4.1.0
 lxml
 reportlab
 pytest>=7.0
+py2app

--- a/setup.cfg
+++ b/setup.cfg
@@ -15,10 +15,6 @@ packages = trelby
 [options]
 python_requires = >=3.9
 packages = find:
-install_requires =
-    wxPython
-    lxml
-    reportlab
 
 [options.entry_points]
 console_scripts =

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,55 @@
+from setuptools import setup
+import os
+
+APP = ["trelby.py"]
+DATA_FILES = [
+    ("trelby", ["trelby/dict_en.dat.gz", "trelby/names.txt.gz", "trelby/manual.html", "trelby/sample.trelby"]),
+    ("trelby/resources", [f"trelby/resources/{f}" for f in os.listdir("trelby/resources") if os.path.isfile(f"trelby/resources/{f}")]),
+]
+
+OPTIONS = {
+    "argv_emulation": True,
+    "iconfile": "resources_mac/icon.icns",
+    "site_packages": True,
+    "includes": ["wx", "lxml", "reportlab"],
+    "excludes": ["tkinter"],
+    "strip": False,
+    "optimize": 2,
+    "plist": {
+        "CFBundleName": "Trelby",
+        "CFBundleDisplayName": "Trelby",
+        "CFBundleIdentifier": "org.trelby.trelby",
+        "CFBundleVersion": "2.4.16.2",
+        "CFBundleShortVersionString": "2.4.16.2",
+        "CFBundleGetInfoString": "Trelby 2.4.16.2 - Free, multiplatform, feature-rich screenwriting program",
+        "CFBundleExecutable": "Trelby",
+        "CFBundleIconFile": "icon.icns",
+        "NSHumanReadableCopyright": "Copyright © 2023 Trelby Team. Licensed under GPL-3.0-or-later.",
+        "NSHighResolutionCapable": True,
+        "LSMinimumSystemVersion": "10.14",
+        "LSApplicationCategoryType": "public.app-category.productivity",
+        "NSRequiresAquaSystemAppearance": False,
+        "CFBundleDocumentTypes": [
+            {
+                "CFBundleTypeName": "Trelby Screenplay",
+                "CFBundleTypeExtensions": ["trelby"],
+                "CFBundleTypeRole": "Editor",
+                "CFBundleTypeIconFile": "icon.icns"
+            }
+        ]
+    },
+    "packages": ["wx", "lxml", "reportlab"],
+    "site_packages": True,
+}
+
+setup(
+    name="Trelby",
+    version="2.4.16.2",
+    description="Free, multiplatform, feature-rich screenwriting program",
+    author="Osku Salerma",
+    url="https://www.trelby.org",
+    app=APP,
+    data_files=DATA_FILES,
+    options={"py2app": OPTIONS},
+    setup_requires=["py2app"],
+)


### PR DESCRIPTION
Changes:

1.  Create a Shell Script to build a dmg file (create a sym link to applications folder)
2. GitHub Actions to build a macOS file for every commit and create a draft release