### PR TITLE
Solve bug and test parsing Command-Line-Interpreter arguments (module `opts`)

### DIFF
--- a/tests/test_opts.py
+++ b/tests/test_opts.py
@@ -1,0 +1,130 @@
+# -*- coding: utf-8 -*-
+
+# pylint: disable=redefined-outer-name
+# pylint: disable=unused-argument
+# ruff: noqa: ARG001
+
+
+"""Test parsing CLI arguments."""
+
+
+from unittest import mock
+from collections.abc import Generator
+
+import pytest
+
+from trelby import opts
+
+
+def _assert_opts(
+        *,
+        is_test: bool = False,
+        conf: str | None = None,
+        filenames: list[str] | None = None
+) -> None:
+    """Assert that CLI arguments are properly parsed.
+
+    Args:
+        is_test: expected value for isTest.
+        conf: expected value for conf.
+        filenames: expected value for filenames.
+
+    """
+
+    if hasattr(opts, 'isTest'):
+        assert opts.isTest is bool(is_test)
+    else:
+        assert is_test is False
+
+    if conf is None:
+        assert getattr(opts, 'conf', None) is None
+    else:
+        assert isinstance(conf, str)
+        assert opts.conf == conf
+
+    if filenames is None:
+        assert getattr(opts, 'filenames', []) == []  # pylint:disable=C1803
+    else:
+        assert isinstance(filenames, list)
+        assert opts.filenames == filenames
+        for filename in opts.filenames:
+            assert isinstance(filename, str)
+
+
+@pytest.fixture
+def reset_opts() -> Generator:
+    """Reset parsed CLI arguments.
+
+    Yields:
+        Nothing.
+
+    """
+
+    _assert_opts()
+
+    yield
+
+    opts.isTest = False
+    opts.conf = None
+    opts.filenames = []
+
+
+def test_parsing_cli_no_args(
+        reset_opts: None, subtests: pytest.Subtests
+) -> None:
+    """Test parsing CLI without arguments."""
+
+    with subtests.test('No CLI arguments.'):
+        argv: list[str] = []
+        with mock.patch('trelby.opts.sys.argv', argv):
+            opts.init()
+        _assert_opts()
+
+    with subtests.test('Only program argument.'):
+        argv = ['spam.py']
+        with mock.patch('trelby.opts.sys.argv', argv):
+            opts.init()
+        _assert_opts()
+
+
+def test_parsing_cli_test(reset_opts: None) -> None:
+    """Test parsing CLI with just --test."""
+
+    argv = ['spam.py', '--test']
+    with mock.patch('trelby.opts.sys.argv', argv):
+        opts.init()
+
+    _assert_opts(is_test=True)
+
+
+def test_parsing_cli_config(reset_opts: None) -> None:
+    """Test parsing CLI with --config."""
+
+    argv = ['spam.py', '--conf', 'ham', 'eggs']
+    with mock.patch('trelby.opts.sys.argv', argv):
+        opts.init()
+
+    _assert_opts(conf='ham', filenames=['eggs'])
+
+
+def test_parsing_cli_config_without_value(reset_opts: None) -> None:
+    """Test parsing CLI with --config without value."""
+
+    argv = ['spam.py', 'eggs', '--conf']
+    with mock.patch('trelby.opts.sys.argv', argv):
+        opts.init()
+
+    _assert_opts(filenames=['eggs'])
+
+
+@pytest.mark.parametrize(
+    'cli_args', [['ham', ], ['eggs', 'ham'], ['bar', 'foo', 'ham']],
+)
+def test_parsing_cli_filenames(reset_opts: None, cli_args: list[str]) -> None:
+    """Test parsing CLI with only filenames."""
+
+    argv = ['spam.py', *cli_args]
+    with mock.patch('trelby.opts.sys.argv', argv):
+        opts.init()
+
+    _assert_opts(filenames=cli_args)

--- a/trelby/opts.py
+++ b/trelby/opts.py
@@ -1,11 +1,25 @@
+# -*- coding: utf-8 -*-
+
+# ruff: noqa:PLW0603
+
+
+"""Parse arguments passed from Command-Line-Interpreter."""
+
+
 import sys
 
 
-# TODO: Python, at least up to 2.4, does not support Unicode command line
-# arguments on Windows. Since UNIXes use UTF-8, just assume all command
-# line arguments are UTF-8 for now, and silently ignore any coding errors
-# that may result on Windows in some cases.
-def init():
+isTest: bool
+conf: str | None
+filenames: list[str]
+
+
+def init() -> None:
+    """Parse arguments passed from CLI via `sys.argv`.
+
+    Sets global isTest, conf and filenames module attributes.
+
+    """
     global isTest, conf, filenames
 
     # script filenames to load
@@ -25,7 +39,7 @@ def init():
             isTest = True
         elif arg == "--conf":
             if (i + 1) < len(sys.argv):
-                conf = str(sys.argv[i + 1], "UTF-8", "ignore")
+                conf = sys.argv[i + 1]
                 i += 1
         else:
             filenames.append(arg)


### PR DESCRIPTION
Hi,

Running `trelby --conf spam` raises a TypeError exception:

```
Traceback (most recent call last):
  File "/opt/local/Library/Frameworks/Python.framework/Versions/Current/bin/trelby", line 7, in <module>
    sys.exit(trelby.main())
             ~~~~~~~~~~~^^
  File "/opt/local/Library/Frameworks/Python.framework/Versions/3.13/lib/python3.13/site-packages/trelby/trelby.py", line 143, in main
    opts.init()
    ~~~~~~~~~^^
  File "/opt/local/Library/Frameworks/Python.framework/Versions/3.13/lib/python3.13/site-packages/trelby/opts.py", line 28, in init
    conf = str(sys.argv[i + 1], "UTF-8", "ignore")
TypeError: decoding str is not supported
```

The root of this bug is that current code tries to prevent issues with CLI while using Windows with Python 2.

```
# TODO: Python, at least up to 2.4, does not support Unicode command line
# arguments on Windows. Since UNIXes use UTF-8, just assume all command
# line arguments are UTF-8 for now, and silently ignore any coding errors
# that may result on Windows in some cases.
```
However those issues have been solved in Python 3 so there is not need to decode arguments from CLI any longer. So line 28 is raising an exception:

```
               conf = str(sys.argv[i + 1], "UTF-8", "ignore")
```

and
 can be refactored as a simple:
```
                conf = sys.argv[i + 1]
```

Additionally, I have write **some tests for the `opts` module**.

Thank you.