### PR TITLE
Polish translation tools, make them more verbose and correct an errata.

### DIFF
--- a/TRANSLATION_NOTES.txt
+++ b/TRANSLATION_NOTES.txt
@@ -1,25 +1,43 @@
-Requirements: gettext, and a po file editor.
+Requirements: gettext and a po file editor.
 
-If you make code changes, please run the following before committing and submitting a pull request:
+
+Before committing and submitting a pull request
+-----------------------------------------------
+
+If you make code changes, please run the following before committing
+and submitting a pull request:
+
+```
 ./t_01_update_pot.sh
-./t_01_update_pot.sh
+./t_02_update_po.sh
 ./t_03_build.sh
+```
 
-These will refresh the .pot file from the current code, update all .po files from the updated .pot,
-and build new .mo files from the .po files.
+These will refresh the .pot file from the current code, update all .po files
+from the updated .pot and build new .mo files from the .po files.
+
 
 To start a translation of a new language (German in this example):
-Using the po editing tool of your choice (I like poedit), create a new .po from the .pot file. Name the file with 
-the appropriate two-digit language code. For German, you'd create po/de.po from po/trelby.po.
+------------------------------------------------------------------
 
-Then populate the translations for all the strings in the new .po.
+*   Using the po editing tool of your choice (I like `poedit`),
+    create a new .po from the .pot file.
 
-To test, run:
+*   Name the file with the appropriate two-digit language code.
+    For German, you'd create po/de.po from po/trelby.po.
+
+*   Then populate the translations for all the strings in the new .po.
+
+*   To test, run:
+
+```
 ./t_03_build.sh
 LANG=de ./trelby.py
+``
 
 And see if things look as expected.
 
-When you're finished, run ./t_03_build.sh, git add the new .po file, commit, push, and submit a pull request.
+When you're finished, run `./t_03_build.sh`, git add the new .po file, commit,
+push, and submit a pull request.
 
 Thank you!

--- a/t_01_update_pot.sh
+++ b/t_01_update_pot.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
-xgettext -j -L Python -o po/trelby.pot \
-	--package-name=trelby \
-        --package-version=2.4.16 \
-        --copyright-holder="Gwyn Ciesla <gwync@protonmail.com>" \
-	$(find ./trelby -type f -name '*.py')
+
+# Update (create) the POT template file for translating Trelby
+
+echo "Creating po/trelby.pot..."
+
+xgettext --language=Python --output=po/trelby.pot --package-name=trelby --package-version=2.4.16 --copyright-holder="Gwyn Ciesla <gwync@protonmail.com>" --keyword=_ --from-code=UTF-8 --sort-by-file $(find ./trelby -type f -name '*.py') trelby.py
+
+echo "File po/trelby.pot created."

--- a/t_02_update_po.sh
+++ b/t_02_update_po.sh
@@ -1,6 +1,12 @@
 #!/bin/bash
 
+# Update the PO files in the `po` directory with the POT template.
+
 for i in $(find po -type f -name '*.po'); do
-  msgmerge -vU "$i" po/trelby.pot
+    echo ""
+    echo "Updating $i"
+    msgmerge --verbose --update --previous --sort-by-file "$i" po/trelby.pot
 done
 
+echo ""
+echo "End."

--- a/t_03_build.sh
+++ b/t_03_build.sh
@@ -1,8 +1,20 @@
 #!/bin/bash
 
+# Compile the PO files and move compiled MO files to `locales` directory
+
 for i in $(find po -type f -name '*.po'); do
-  j=$(echo "$i" | sed "s|\.\/||g" | sed "s|\.po||g" | cut -f 2 -d "/")
-  mkdir -p trelby/locales/"$j"/LC_MESSAGES
-  msgfmt -otrelby/locales/"$j"/LC_MESSAGES/trelby.mo "$i"
+
+    j=$(echo "$i" | sed "s|\.\/||g" | sed "s|\.po||g" | cut -f 2 -d "/")
+
+    echo ""
+    echo "Compiling $j at trelby/locales/$j/LC_MESSAGES/trelby.mo"
+
+    mkdir -p trelby/locales/"$j"/LC_MESSAGES
+    msgfmt --verbose --statistics --output-file=trelby/locales/"$j"/LC_MESSAGES/trelby.mo "$i"
+
 done
+
 rm -f po/*.mo
+
+echo ""
+echo "End."


### PR DESCRIPTION
I am proposing to give a facelift to the bash scripts used as translation tools for the project. There are two reasons:

1. First, and most important, the parameter ‘-j’, ‘--join-existing’ (“Join messages with existing file.”, according to docs) for `xgettext`  in `t_01_update_pot.sh` is causing me a little trouble in commits, merges, etc.

2. There is a little errata in `TRANSLATION_NOTES.txt`. Because of that, I am not running `t_02_update_po.sh` for a while, causing some confusion in my beginner's mind and workflow.

Changes are:

* **remove `-j`** (‘--join-existing’) parameter from `xgettext` in `t_01_update_pot.sh`. Joining messages with existing file cause a mess in my repository.

* add `--sort-by-file` to `xgettext`  in `t_01_update_pot.sh` and to `msgmerge` in `t_02_update_po.sh`. They make commits shorter and cleaner and comparing .po and .pot files is easier and straightforward.

* make scripts more **verbose**: they output more information about what they are doing and the results of the commands that run. Additionally, as a beginner, I prefer long parameters for scripts (they make more explicit what the command is going to do).

* Errata was removed from `TRANSLATION_NOTES.txt` so no need to invoke ./t_01_update_pot.sh twice ;-).

* Minor changes in `TRANSLATION_NOTES.txt` for a cleaner presentation.

I hope that those changes will be welcome and will make the life of any translator easier. Thank you.
 